### PR TITLE
Add uploadArchive task

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
+def GROUP_ID = 'com.cookpad'
+def ARTIFACT_ID = 'issue-reporter-android'
 def VERSION_CODE = 1
 def VERSION_NAME = '1.0.2'
 
@@ -31,4 +34,13 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-v4:20.0.0'
+}
+
+uploadArchives {
+    repositories.mavenDeployer {
+        repository url: "file://$System.env.HOME/.m2/repository"
+        pom.version = VERSION_NAME
+        pom.groupId = GROUP_ID
+        pom.artifactId = ARTIFACT_ID
+    }
 }


### PR DESCRIPTION
App developer can upload this library as maven artifact to their local repository. 

```
$ ./gradlew clean uploadArchive
```

After that, they can use this library by adding the following entries to build.gradle

```
repositories {
    mavenLocal()
}

dependencies {
    debugCompile 'com.cookpad:issue-reporter-android:1.0.2'
}
```
